### PR TITLE
Add new equation for equilibrium maternal immunity

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -142,17 +142,12 @@ human_equilibrium_no_het <- function(EIR, ft, p, age) {
   IM0 <- ICA[age20]*p$PM
   ICM <- rep(0, n_age)
   for (i in 1:n_age) {
-    
-    # rate of ageing plus death
-    re <- r[i] + p$eta
-    
     # maternal clinical immunity decays from birth
-    if (i == 1) {
-      ICM_prev <- IM0
+    if (i == n_age) {
+      ICM[i] <- 0
     } else {
-      ICM_prev <- ICM[i-1]
+      ICM[i] <- IM0 * p$dm / (age_days[i + 1] - age_days[i]) * (exp(-age_days[i] / p$dm) - exp(-age_days[i + 1] / p$dm))
     }
-    ICM[i] <- ICM_prev*re/(1/p$dm + re)
   }
   
   # calculate probability of acquiring clinical disease as a function of


### PR DESCRIPTION
This equation for maternal immunity gives different results to Jamie's C++ version.

## Plots

These are the compartment proportions in each age group currently. The C++ version is from outputs of Jamie's Malaria_model. The R version is this package.

NOTE: the increased D counts for younger age groups.

![states_before](https://user-images.githubusercontent.com/2605711/116241710-1d483280-a75d-11eb-9c03-d385a46a73ed.png)

These are the mean immunity values for each age group.

![immunity_before](https://user-images.githubusercontent.com/2605711/116241858-42d53c00-a75d-11eb-8b13-fbc24ffe21a5.png)

After we change the ICM formula in the R version to match the C++ one (you can find that [here](https://github.com/mrc-ide/Malaria_model/blob/master/code/equilibrium/malaria_parms.cpp#L525)) we get these plots...

![states_after](https://user-images.githubusercontent.com/2605711/116241728-233e1380-a75d-11eb-8c60-5d7e8a4d89bb.png)
![immunities_after](https://user-images.githubusercontent.com/2605711/116241738-25a06d80-a75d-11eb-96d7-523c22465cb7.png)


Is it ok to use this new model for ICM?
Does the change make sense?

