### PR TITLE
Changes to make malariaEquilibrium play nice with the odin model

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -254,7 +254,9 @@ human_equilibrium_no_het <- function(EIR, ft, p, age) {
      B = B,
      FOI = FOI,
      phi = phi,
-     EPS = EPS
+     EPS = EPS,
+     cA = cA,
+     r = r
   )
   return(ret)
 }


### PR DESCRIPTION
Very small changes to output of `human_equilibrium_no_het` function to pass out `r` (equivalent to `age_rate` in odin model) and `cA` (infectiousness to mosquitoes from asymptomatic compartment). 

New outputs get used in the odin model here: https://github.com/mrc-ide/dide-deterministic-malaria-model/blob/bdc734afac9cde74df5644795a2e569f98cf1213/R/equilibrium-solution.R#L64